### PR TITLE
AwsConfig object when creating ec2client for terminating instances.

### DIFF
--- a/src/ConDep.Dsl.Operations.Aws/Bootstrap/AwsBootstrapMandatoryConfig.cs
+++ b/src/ConDep.Dsl.Operations.Aws/Bootstrap/AwsBootstrapMandatoryConfig.cs
@@ -1,4 +1,6 @@
-﻿namespace ConDep.Dsl.Operations.Application.Local.Bootstrap.Aws
+﻿using Amazon;
+
+namespace ConDep.Dsl.Operations.Application.Local.Bootstrap.Aws
 {
     public class AwsBootstrapMandatoryConfig : IOfferAwsBootstrapMandatoryConfig
     {
@@ -55,6 +57,7 @@
         public string PrivateKeyFileLocation { get; set; }
         public string SubnetId { get; set; }
         public string Region { get; set; }
+        public RegionEndpoint RegionEndpoint { get; set; }
 
         public string BootstrapId
         {

--- a/src/ConDep.Dsl.Operations.Aws/Terminate/Ec2Terminator.cs
+++ b/src/ConDep.Dsl.Operations.Aws/Terminate/Ec2Terminator.cs
@@ -20,7 +20,9 @@ namespace ConDep.Dsl.Operations.Aws.Terminate
             _mandatoryOptions = mandatoryOptions;
 
             AWSCredentials creds = _mandatoryOptions.Credentials.UseProfile ? (AWSCredentials)new StoredProfileAWSCredentials(_mandatoryOptions.Credentials.ProfileName) : new BasicAWSCredentials(_mandatoryOptions.Credentials.AccessKey, _mandatoryOptions.Credentials.SecretKey);
-            _client = AWSClientFactory.CreateAmazonEC2Client(creds);
+            AmazonEC2Config config = new AmazonEC2Config { RegionEndpoint = _mandatoryOptions.RegionEndpoint };
+
+            _client = AWSClientFactory.CreateAmazonEC2Client(creds, config);
 
             _instanceHandler = new Ec2InstanceHandler(_client);
         }

--- a/src/ConDep.Dsl.Operations.Aws/Terminate/TerminateExtensions.cs
+++ b/src/ConDep.Dsl.Operations.Aws/Terminate/TerminateExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using Amazon;
 using Amazon.Runtime;
 using ConDep.Dsl.Config;
 using ConDep.Dsl.Operations.Application.Local;
@@ -62,6 +63,7 @@ namespace ConDep.Dsl.Operations.Aws.Terminate
                 _mandatoryOptions.PrivateKeyFileLocation = config.PrivateKeyFileLocation;
                 _mandatoryOptions.SubnetId = config.SubnetId;
                 _mandatoryOptions.Region = config.Region;
+                _mandatoryOptions.RegionEndpoint = GetRegionEndpoint(config.Region);
 
                 string profileName = config.Credentials.ProfileName;
                 if (string.IsNullOrEmpty(profileName))
@@ -93,6 +95,25 @@ namespace ConDep.Dsl.Operations.Aws.Terminate
                     string.Format("Configuration extraction for {0} failed during binding. Please check inner exception for details.",
                         GetType().Name), binderException);
             }
+        }
+
+        private RegionEndpoint GetRegionEndpoint(string region)
+        {
+            if (region == "us-east-1")
+                return RegionEndpoint.USEast1;
+            if (region == "us-west-1")
+                return RegionEndpoint.USWest1;
+            if (region == "us-west-2")
+                return RegionEndpoint.USWest2;
+            if (region == "ap-southeast-1")
+                return RegionEndpoint.APSoutheast1;
+            if (region == "ap-southeast-2")
+                return RegionEndpoint.APSoutheast2;
+            if (region == "ap-northeast-1")
+                return RegionEndpoint.APNortheast1;
+            if (region == "sa-east-1")
+                return RegionEndpoint.SAEast1;
+            return RegionEndpoint.EUWest1;
         }
 
 


### PR DESCRIPTION
Added AwsConfig object when creating ec2client for terminating instances. The config object contains the RegionEndpoint that I had to set to make termination work properly. RegionEndpoint is based on the mandatory Region field in the ConDep environment config file.
